### PR TITLE
Rejuvenate log levels.

### DIFF
--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/IRCTApplication.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/IRCTApplication.java
@@ -70,22 +70,22 @@ public class IRCTApplication {
 		this.oem = objectEntityManager.createEntityManager();
 		this.oem.setFlushMode(FlushModeType.COMMIT);
 
-		log.info("Loading Data Converters");
+		log.finest("Loading Data Converters");
 		loadDataConverters();
 		log.info("Finished Data Converters");
 
-		log.info("Loading Event Listeners");
+		log.finest("Loading Event Listeners");
 		loadIRCTEventListeners();
 		log.info("Finished Loading Event Listeners");
 
 		this.oem = objectEntityManager.createEntityManager();
 		this.oem.setFlushMode(FlushModeType.COMMIT);
 
-		log.info("Loading Join Types");
+		log.finest("Loading Join Types");
 		loadJoins();
 		log.info("Finished Loading Join Types");
 
-		log.info("Loading Resources");
+		log.finest("Loading Resources");
 		loadResources();
 		log.info("Finished Loading Resources");
 
@@ -135,7 +135,7 @@ public class IRCTApplication {
 			irctEventListener.registerListener(irctEvent);
 		}
 
-		log.info("Loaded " + allEventListeners.size() + " IRCT Event listeners");
+		log.finer("Loaded " + allEventListeners.size() + " IRCT Event listeners");
 	}
 
 	/**
@@ -160,7 +160,7 @@ public class IRCTApplication {
 
 		}
 
-		log.info("Loaded " + allDCI.size() + " result data converters");
+		log.finest("Loaded " + allDCI.size() + " result data converters");
 	}
 
 	/**
@@ -177,7 +177,7 @@ public class IRCTApplication {
 		for (IRCTJoin jt : oem.createQuery(criteria).getResultList()) {
 			this.supportedJoinTypes.put(jt.getName(), jt);
 		}
-		log.info("Loaded " + this.supportedJoinTypes.size() + " joins");
+		log.finest("Loaded " + this.supportedJoinTypes.size() + " joins");
 	}
 
 	/**
@@ -193,19 +193,19 @@ public class IRCTApplication {
 		CriteriaQuery<Resource> criteria = cb.createQuery(Resource.class);
 		Root<Resource> load = criteria.from(Resource.class);
 		criteria.select(load);
-		log.info("loadResources() "+criteria.toString());
+		log.fine("loadResources() "+criteria.toString());
 		for (Resource resource : oem.createQuery(criteria).getResultList()) {
 			try {
-				log.info("loadResources() Setting up resource:"+resource.toString()+" "+resource.getId()+" "+resource.getClass().toString());
+				log.fine("loadResources() Setting up resource:"+resource.toString()+" "+resource.getId()+" "+resource.getClass().toString());
 				resource.setup();
-				log.info("loadResources() resource ```"+resource.getName()+"``` has been loaded");
+				log.fine("loadResources() resource ```"+resource.getName()+"``` has been loaded");
 				this.resources.put(resource.getName(), resource);
 			} catch (ResourceInterfaceException e) {
 				log.warning("loadResources() Exception: "+e.getMessage());
 				e.printStackTrace();
 			}
 		}
-		log.info("loadResources() Loaded " + this.resources.size() + " resources");
+		log.fine("loadResources() Loaded " + this.resources.size() + " resources");
 	}
 
 	/**

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/PathController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/PathController.java
@@ -57,7 +57,7 @@ public class PathController {
 	public List<Entity> traversePath(Resource resource, Entity resourcePath,
 			OntologyRelationship relationship, SecureSession session)
 			throws ResourceInterfaceException {
-		logger.log(Level.FINE, "traversePath() resource:"+resource.getName()+" resourcePath:"+resourcePath.toString());
+		logger.log(Level.FINER, "traversePath() resource:"+resource.getName()+" resourcePath:"+resourcePath.toString());
 		
 		if (resource.getImplementingInterface() == null) {
 			logger.log(Level.FINE, "traversePath() is an interface implementing NULL");
@@ -70,7 +70,7 @@ public class PathController {
 		} else {
 			logger.log(Level.SEVERE, "traversePath() resource ```"+resource.getName()+"``` does not implement PathResource");
 		}
-		logger.log(Level.FINE, "traversePath() returning NULL");
+		logger.log(Level.FINER, "traversePath() returning NULL");
 		return null;
 	}
 

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
@@ -57,7 +57,7 @@ public class ProcessController {
 		} else {
 			entityManager.merge(this.process);
 		}
-		log.info("Process " + this.process.getId() + " saved");
+		log.finest("Process " + this.process.getId() + " saved");
 
 	}
 
@@ -76,7 +76,7 @@ public class ProcessController {
 		if (this.process == null) {
 			throw new ProcessException("No process to load.");
 		}
-		log.info("Query " + this.process.getId() + " loaded");
+		log.finest("Query " + this.process.getId() + " loaded");
 	}
 
 	/**

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/QueryController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/QueryController.java
@@ -450,7 +450,7 @@ public class QueryController {
 		} else {
 			entityManager.merge(this.query);
 		}
-		log.info("Query " + this.query.getId() + " saved");
+		log.finest("Query " + this.query.getId() + " saved");
 
 	}
 
@@ -471,7 +471,7 @@ public class QueryController {
 		if (this.query == null) {
 			throw new QueryException("No query to load.");
 		}
-		log.info("Query " + this.query.getId() + " loaded");
+		log.finest("Query " + this.query.getId() + " loaded");
 	}
 
 	/**

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResourceController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResourceController.java
@@ -150,7 +150,7 @@ public class ResourceController {
 			logger.log(Level.FINE, "isValidCategory(`"+categoryName+"`) missing `categories` list.");
 			return false;
 		}
-		logger.log(Level.FINE, "isValidCategory(`"+categoryName+"`) in "+this.categories.toString());
+		logger.log(Level.FINEST, "isValidCategory(`"+categoryName+"`) in "+this.categories.toString());
 		return this.categories.contains(categoryName);
 	}
 

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResultController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResultController.java
@@ -139,7 +139,7 @@ public class ResultController {
 	public ResultDataStream getResultDataStream(User user, Long resultId,
 			String format) {
 		
-		logger.log(Level.FINE, "getResultDataStream() user:"+user.getName()+" resultId:"+resultId+" format:"+(format==null?"NULL":format));
+		logger.log(Level.FINER, "getResultDataStream() user:"+user.getName()+" resultId:"+resultId+" format:"+(format==null?"NULL":format));
 		ResultDataStream rds = new ResultDataStream();
 		List<Result> results = getResults(user, resultId);
 
@@ -147,11 +147,11 @@ public class ResultController {
 			rds.setMessage("Unable to find result");
 			return rds;
 		} else {
-			logger.log(Level.FINE, "getResultDataStream() there are ```"+results.size()+"``` results found.");
+			logger.log(Level.FINER, "getResultDataStream() there are ```"+results.size()+"``` results found.");
 		}
 		Result result = results.get(0);
 		
-		logger.log(Level.FINE, "getResultDataStream() The first result status is "+result.getResultStatus().name());
+		logger.log(Level.FINER, "getResultDataStream() The first result status is "+result.getResultStatus().name());
 		if(result.getResultStatus() != ResultStatus.AVAILABLE) {
 			rds.setMessage("Result is not available");
 			return rds;
@@ -160,7 +160,7 @@ public class ResultController {
 		ResultDataConverter rdc = irctApp.getResultDataConverter(
 				result.getDataType(), format);
 		
-		logger.log(Level.FINE, "getResultDataStream() ResultDataConverter has been retrieved");
+		logger.log(Level.FINER, "getResultDataStream() ResultDataConverter has been retrieved");
 		if (rdc == null) {
 			rds.setMessage("Unable to find format");
 			return rds;
@@ -231,7 +231,7 @@ public class ResultController {
 	 */
 	public Result createResult(ResultDataType resultDataType)
 			throws PersistableException {
-		logger.log(Level.FINE, "createResult() "+resultDataType.toString());
+		logger.log(Level.FINER, "createResult() "+resultDataType.toString());
 		
 		Result result = new Result();
 		entityManager.persist(result);
@@ -247,7 +247,7 @@ public class ResultController {
 					+ "/" + result.getId());
 			result.setData(frs);
 		} else if (resultDataType == ResultDataType.JSON) {
-			logger.log(Level.FINE, "createResult() JSON DataType is NOT persisted!!!");
+			logger.log(Level.FINER, "createResult() JSON DataType is NOT persisted!!!");
 		} else {
 			result.setResultStatus(ResultStatus.ERROR);
 			result.setMessage("Unknown Result Data Type");

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/SecurityController.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/SecurityController.java
@@ -70,7 +70,7 @@ public class SecurityController {
 			entityManager.merge(ss);
 		}
 
-		log.info("Created key for " + user.getName());
+		log.finest("Created key for " + user.getName());
 
 		return key;
 	}
@@ -109,7 +109,7 @@ public class SecurityController {
 
 		SecureSession ss = ssl.get(0);
 
-		log.info("Found valid key for " + ss.getUser().getName());
+		log.finest("Found valid key for " + ss.getUser().getName());
 		return ss;
 	}
 

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/event/IRCTEventListener.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/event/IRCTEventListener.java
@@ -306,16 +306,16 @@ public class IRCTEventListener {
 	 *            Result
 	 */
 	public void beforeGetResult(User user, Long resultId) {
-		logger.log(Level.FINE, "beforeGetResult() user:"+user.getName()+" resultId:"+resultId);
+		logger.log(Level.FINER, "beforeGetResult() user:"+user.getName()+" resultId:"+resultId);
 		
-		logger.log(Level.FINE, "beforeGetResult() selecting ```BeforeGetResult``` from "+(events==null?"null":events.size())+" events.");
+		logger.log(Level.FINER, "beforeGetResult() selecting ```BeforeGetResult``` from "+(events==null?"null":events.size())+" events.");
 		List<IRCTEvent> irctEvents = events.get("BeforeGetResult");
 		if (irctEvents == null) {
-			logger.log(Level.FINE, "beforeGetResult() There were no ```BeforeGetResult``` events.");
+			logger.log(Level.FINER, "beforeGetResult() There were no ```BeforeGetResult``` events.");
 		} else {
-			logger.log(Level.FINE, "beforeGetResult() executing "+(irctEvents==null?"null":irctEvents.size())+" events.");
+			logger.log(Level.FINER, "beforeGetResult() executing "+(irctEvents==null?"null":irctEvents.size())+" events.");
 			for (IRCTEvent irctEvent : irctEvents) {
-				logger.log(Level.FINE, "beforeGetResult() firing "+(((BeforeGetResult) irctEvent)==null?"null":((BeforeGetResult) irctEvent).toString())+" event.");
+				logger.log(Level.FINER, "beforeGetResult() firing "+(((BeforeGetResult) irctEvent)==null?"null":((BeforeGetResult) irctEvent).toString())+" event.");
 				((BeforeGetResult) irctEvent).fire(user, resultId);
 			}
 			logger.log(Level.FINE, "beforeGetResult() Finished firing all ```BeforeGetResult``` events.");
@@ -329,12 +329,12 @@ public class IRCTEventListener {
 	 *            Result
 	 */
 	public void beforeSaveResult(Result result) {
-		logger.log(Level.FINE, "beforeSaveResult() result:"+(result==null?"null":result.getId()));
+		logger.log(Level.FINEST, "beforeSaveResult() result:"+(result==null?"null":result.getId()));
 		
-		logger.log(Level.FINE, "beforeSaveResult() selecting all ```BeforeSaveResult``` from "+(events==null?"null":events.size())+" events.");
+		logger.log(Level.FINEST, "beforeSaveResult() selecting all ```BeforeSaveResult``` from "+(events==null?"null":events.size())+" events.");
 		List<IRCTEvent> irctEvents = events.get("BeforeSaveResult");
 		if (irctEvents == null) {
-			logger.log(Level.FINE, "beforeSaveResult() there are no ```BeforeSaveResult``` events.");
+			logger.log(Level.FINEST, "beforeSaveResult() there are no ```BeforeSaveResult``` events.");
 		} else {
 			for (IRCTEvent irctEvent : irctEvents) {
 				((BeforeSaveResult) irctEvent).fire(result);

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/model/result/Result.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/model/result/Result.java
@@ -21,7 +21,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
-import org.apache.commons.logging.impl.Log4JLogger;
+import org.apache.log4j.Logger;
 
 import edu.harvard.hms.dbmi.bd2k.irct.executable.Executable;
 import edu.harvard.hms.dbmi.bd2k.irct.model.security.User;
@@ -42,7 +42,7 @@ public class Result {
 	@SequenceGenerator(name = "resultSequencer", sequenceName = "resSeq")
 	private Long id;
 	
-	private Log4JLogger logger = new Log4JLogger();
+	private Logger logger = Logger.getLogger(getClass());
 
 	// TODO: REMOVE TRANSIENT
 	@Transient

--- a/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/security/SecurityUtility.java
+++ b/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/security/SecurityUtility.java
@@ -46,33 +46,33 @@ public class SecurityUtility {
 			String resourceClientId, SecureSession session) {
 
 		if (session.getToken() != null) {
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() returning token stored in the session:"+session.getToken().toString());
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() returning token stored in the session:"+session.getToken().toString());
 			return session.getToken().toString();
 		} else {
 			java.util.logging.Logger.getGlobal().log(Level.SEVERE, "delegateToken() session DOES NOT CONTAINT A TOKEN!");
 		}
 
-		java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() namespace:"+namespace+" resource.client.id:"+resourceClientId+" session.id:"+session.getId());
+		java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() namespace:"+namespace+" resource.client.id:"+resourceClientId+" session.id:"+session.getId());
 
 		if (((JWT) session.getToken()).getClientId().equals(resourceClientId)) {
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() session token matches the specified resourceClientId");
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() session token matches the specified resourceClientId");
 			return session.getToken().toString();
 		} else {
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() session token DOES NOT MATCH the specified resourceClientId");
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() session token DOES NOT MATCH the specified resourceClientId");
 		}
 
 		if (session.getDelegated().containsKey(resourceClientId)) {
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() returning a Bearer token");
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() returning a Bearer token");
 			return "Bearer "
 					+ session.getDelegated().get(resourceClientId).toString();
 		} else {
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() session does NOT have a delegated token.");
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() session does NOT have a delegated token.");
 		}
 
 		try {
 			HttpClient client = HttpClientBuilder.create().build();
 			HttpPost post = new HttpPost("https://" + namespace + "/delegation");
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() call to ```https://"+namespace+"/delegation``` URL.");
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() call to ```https://"+namespace+"/delegation``` URL.");
 
 			List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
 			urlParameters.add(new BasicNameValuePair("grant_type",
@@ -107,7 +107,7 @@ public class SecurityUtility {
 			jwt.setType(responseObject.getString("token_type"));
 			jwt.setIdToken(responseObject.getString("id_token"));
 			session.getDelegated().put(resourceClientId, jwt);
-			java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() returning new delegation token:"+responseObject.getString("id_token"));
+			java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() returning new delegation token:"+responseObject.getString("id_token"));
 			return "Bearer " + responseObject.getString("id_token");
 
 		} catch (IOException e) {
@@ -115,7 +115,7 @@ public class SecurityUtility {
 			e.printStackTrace();
 		}
 
-		java.util.logging.Logger.getGlobal().log(Level.FINE, "delegateToken() returning NULL, after exception.");
+		java.util.logging.Logger.getGlobal().log(Level.WARNING, "delegateToken() returning NULL, after exception.");
 		return null;
 	}
 }


### PR DESCRIPTION
Introduction
---
We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

Feedback Request
---
We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on each of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
2. Never lower the logging level of logging statements within catch blocks.
3. Never lower the logging level of logging statements within if statements.
4. Never lower the logging level of logging statements containing certain (important) keywords.
5. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
6. The greatest number of commits from HEAD evaluated: 1000.

The head at time of analysis was: [aa0f039](https://github.com/hms-dbmi/IRCT-API/commit/aa0f039f454834e78affc94e159bb76a1ffefed1)